### PR TITLE
draft: feat: support regex on string/text/richtext fields

### DIFF
--- a/admin/src/components/Generate/Generate.tsx
+++ b/admin/src/components/Generate/Generate.tsx
@@ -49,7 +49,7 @@ const Generate = ({ attributes, checkedAttributes, values, count, onChangeGenera
 		return faker.lorem.words({ min, max });
 	};
 	const getValueByEmailType = (): string => {
-		return faker.internet.email({ provider: "element-software.co.uk" }).toLowerCase();
+		return faker.internet.email().toLowerCase();
 	};
 	const getValueByDateType = (key: string): Date => {
 		let { from, to } = values[key] as {

--- a/admin/src/components/Generate/Generate.tsx
+++ b/admin/src/components/Generate/Generate.tsx
@@ -19,6 +19,10 @@ interface Props {
 }
 
 const Generate = ({ attributes, checkedAttributes, values, count, onChangeGenerateData }: Props) => {
+	const capitalizeFirstLetter = (str: string): string => {
+		return str.charAt(0).toUpperCase() + str.slice(1);
+	  }
+	
 	const getValueByIntegerType = (key: string): number => {
 		let { min, max } = values[key] as {
 			min: number;
@@ -36,13 +40,14 @@ const Generate = ({ attributes, checkedAttributes, values, count, onChangeGenera
 	};
 
 	const getValueByStringAndRichtextType = (key: string, regex?: string): string => {
+		console.log("REGGGGGGGGGGGGGGGGGGGGGGGGGG", regex);
 		if (regex) {
-			console.log("regex", regex);
 			return faker.helpers.fromRegExp(regex);
 		}
 		let { min, max } = values[key] as { min: number; max: number };
 		console.log("min", min, "max", max);
 		if (!min && !max) return faker.lorem.words();
+		if (min === 1 && max === 1) return capitalizeFirstLetter(faker.lorem.words(1));
 		return faker.lorem.words({ min, max });
 	};
 	const getValueByEmailType = (): string => {
@@ -187,6 +192,11 @@ const Generate = ({ attributes, checkedAttributes, values, count, onChangeGenera
 		};
 
 		console.log("type", type, "key", key, "relationArray", relationArray, "regex", regex);
+
+		if (type === AttributeType.String || type === AttributeType.Text || type === AttributeType.Richtext) {
+			console.log("type", type, "key", key, "relationArray", relationArray, "regex", regex);
+			return obj[type](key, regex);
+		}
 		// @ts-ignore
 		return obj[type](key, relationArray[key], regex);
 	};
@@ -234,6 +244,7 @@ const Generate = ({ attributes, checkedAttributes, values, count, onChangeGenera
 							console.log(attributes[key], " has regex: ", attributes[key].regex);
 							obj[key] = getGeneratedDataByType(attributes[key].type, key, relationData, attributes[key].regex);
 						} else {
+							console.log(attributes[key], " does not have regex: ");
 							obj[key] = getGeneratedDataByType(attributes[key].type, key, relationData);
 						}
 					});

--- a/admin/src/components/Generate/Generate.tsx
+++ b/admin/src/components/Generate/Generate.tsx
@@ -40,18 +40,15 @@ const Generate = ({ attributes, checkedAttributes, values, count, onChangeGenera
 	};
 
 	const getValueByStringAndRichtextType = (key: string, regex?: string): string => {
-		console.log("REGGGGGGGGGGGGGGGGGGGGGGGGGG", regex);
 		if (regex) {
 			return faker.helpers.fromRegExp(regex);
 		}
 		let { min, max } = values[key] as { min: number; max: number };
-		console.log("min", min, "max", max);
 		if (!min && !max) return faker.lorem.words();
 		if (min === 1 && max === 1) return capitalizeFirstLetter(faker.lorem.words(1));
 		return faker.lorem.words({ min, max });
 	};
 	const getValueByEmailType = (): string => {
-		console.log("getValueByEmailType");
 		return faker.internet.email({ provider: "element-software.co.uk" }).toLowerCase();
 	};
 	const getValueByDateType = (key: string): Date => {
@@ -173,7 +170,6 @@ const Generate = ({ attributes, checkedAttributes, values, count, onChangeGenera
 		relationArray: { [key: string]: number[] },
 		regex?: string
 	): any => {
-		//console.log(type, key, relationArray);
 		let obj = {
 			[AttributeType.Integer]: getValueByIntegerType,
 			[AttributeType.String]: getValueByStringAndRichtextType,
@@ -191,10 +187,8 @@ const Generate = ({ attributes, checkedAttributes, values, count, onChangeGenera
 			[AttributeType.JSON]: getValueByJSONType
 		};
 
-		console.log("type", type, "key", key, "relationArray", relationArray, "regex", regex);
 
 		if (type === AttributeType.String || type === AttributeType.Text || type === AttributeType.Richtext) {
-			console.log("type", type, "key", key, "relationArray", relationArray, "regex", regex);
 			return obj[type](key, regex);
 		}
 		// @ts-ignore
@@ -231,8 +225,6 @@ const Generate = ({ attributes, checkedAttributes, values, count, onChangeGenera
 			for (let i = 0; i < count; i++) {
 				let obj: { [key: string]: string | string[] } = {};
 				let UIDsWithTargetField: [string, Attribute][] = [];
-				console.log("attributes", attributes);
-				console.log("checkedAttributes", checkedAttributes);
 				Object.keys(attributes)
 					.filter((key) => checkedAttributes.includes(key))
 					.forEach((key) => {
@@ -241,10 +233,8 @@ const Generate = ({ attributes, checkedAttributes, values, count, onChangeGenera
 						}
 
 						if ((attributes[key].type === AttributeType.String || AttributeType.Text || AttributeType.Richtext) && attributes[key].regex) {
-							console.log(attributes[key], " has regex: ", attributes[key].regex);
 							obj[key] = getGeneratedDataByType(attributes[key].type, key, relationData, attributes[key].regex);
 						} else {
-							console.log(attributes[key], " does not have regex: ");
 							obj[key] = getGeneratedDataByType(attributes[key].type, key, relationData);
 						}
 					});

--- a/admin/src/pages/HomePage/config.tsx
+++ b/admin/src/pages/HomePage/config.tsx
@@ -56,6 +56,8 @@ export const getAttributeInputs = ({
 		values
 	});
 
+
+
 	return {
 		[AttributeType.Integer]: (
 			<IntegerInputs

--- a/admin/src/pages/HomePage/index.tsx
+++ b/admin/src/pages/HomePage/index.tsx
@@ -98,7 +98,7 @@ const HomePage: React.FC = () => {
 						) {
 							obj[key] = {
 								min: attributes[key].min || 1,
-								max: attributes[key].max || 10
+								max: attributes[key].max || 1
 							};
 						}
 						if (type === AttributeType.Date) {
@@ -230,7 +230,7 @@ const HomePage: React.FC = () => {
 			<HeaderLayout
 				title='Generate data'
 				subtitle='Generate data for your content types'
-				as='h1'
+				as='h2'
 				primaryAction={
 					attributes &&
 					values && (

--- a/admin/src/pages/HomePage/types.ts
+++ b/admin/src/pages/HomePage/types.ts
@@ -30,4 +30,5 @@ export type Attribute = {
 	max: number;
 	multiple: boolean;
 	allowedTypes: AllowedTypes[];
+	regex?: string;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,23 @@
 {
   "name": "strapi-plugin-generate-data",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-plugin-generate-data",
-      "version": "1.0.27",
+      "version": "1.0.28",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@faker-js/faker": "^7.6.0",
+        "@faker-js/faker": "^8.1.0",
         "@strapi/design-system": "^1.6.3",
         "@strapi/helper-plugin": "^4.6.1",
         "@strapi/icons": "^1.11.0",
         "axios": "^0.27.2",
         "mime-types": "^2.1.35",
         "qs": "^6.11.0",
+        "randexp": "^0.5.3",
         "slugify": "^1.6.5",
         "typescript": "4.9.5"
       },
@@ -2483,12 +2484,18 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
-      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.1.0.tgz",
+      "integrity": "sha512-38DT60rumHfBYynif3lmtxMqMqmsOQIxQgEuPZxCk2yUYN0eqWpTACgxi0VpidvsJB8CRxCpvP7B3anK85FjtQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@fingerprintjs/fingerprintjs": {
@@ -7549,6 +7556,14 @@
       "peer": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/drange": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -13716,6 +13731,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/randexp": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+      "dependencies": {
+        "drange": "^1.0.2",
+        "ret": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/randexp/node_modules/ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -19199,9 +19234,9 @@
       "peer": true
     },
     "@faker-js/faker": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
-      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw=="
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.1.0.tgz",
+      "integrity": "sha512-38DT60rumHfBYynif3lmtxMqMqmsOQIxQgEuPZxCk2yUYN0eqWpTACgxi0VpidvsJB8CRxCpvP7B3anK85FjtQ=="
     },
     "@fingerprintjs/fingerprintjs": {
       "version": "3.3.6",
@@ -23361,6 +23396,11 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
       "peer": true
+    },
+    "drange": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA=="
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -28142,6 +28182,22 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "peer": true
+    },
+    "randexp": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+      "requires": {
+        "drange": "^1.0.2",
+        "ret": "^0.2.0"
+      },
+      "dependencies": {
+        "ret": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+          "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
+        }
+      }
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -24,13 +24,14 @@
     "url": "https://github.com/MaksZhukov/strapi-generate-data.git"
   },
   "dependencies": {
-    "@faker-js/faker": "^7.6.0",
+    "@faker-js/faker": "^8.1.0",
     "@strapi/design-system": "^1.6.3",
     "@strapi/helper-plugin": "^4.6.1",
     "@strapi/icons": "^1.11.0",
     "axios": "^0.27.2",
     "mime-types": "^2.1.35",
     "qs": "^6.11.0",
+    "randexp": "^0.5.3",
     "slugify": "^1.6.5",
     "typescript": "4.9.5"
   },


### PR DESCRIPTION
When generating data, if a field has a regex, this is not used - now the data can be generated to match the regex. Below is an example of the field 'Phone' having a regex pattern `[0-9]{5,25}`:

![image](https://github.com/MaksZhukov/strapi-plugin-generate-data/assets/81567707/6702deb5-fd78-48fa-b190-9235eab30764)

Generating the data for the content type 'Customer' gives the below:
![image](https://github.com/MaksZhukov/strapi-plugin-generate-data/assets/81567707/6cd5cccd-514a-40db-9b18-111efe415add)

- default min and max words changed to 1 instead of 1 and 10
![image](https://github.com/MaksZhukov/strapi-plugin-generate-data/assets/81567707/cd46a239-d607-48b9-a011-f13bc4b467c5)

- updated fakerjs version to latest and updated use of deprecated functions
- added a `capitalizeFirstLetter` function in `Generate.tsx`
- hardcoded my email address as the provider when generating email addresses - not yet had a change to make this field customisable (still getting to grips with the codebase)

No unit tests for me to add/update unfortunately...

