### PR TITLE
fix: respect minSymbols

### DIFF
--- a/admin/src/components/Generate/Generate.tsx
+++ b/admin/src/components/Generate/Generate.tsx
@@ -68,7 +68,7 @@ const Generate = ({
 			.split(' ')
 			.map((item) => {
 				let randomIndex = faker.number.int({
-					min: 1,
+					min: minSymbols,
 					max: maxSymbols
 				});
 				return item.slice(0, randomIndex);


### PR DESCRIPTION
fixes a bug where if max words > 1, it can generate strings shorter than the min symbols